### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Remotes:
 Depends:
     R (>= 3.2.2)
 Suggests:
-    stephenturner/annotables
+ annotables
 License: GPL-3
 LazyData: true
 RoxygenNote: 7.2.3


### PR DESCRIPTION
Error while installing the package:

Malformed Depends or Suggests or Imports or Enhances field.
   Offending entries:
     stephenturner/annotables
   Entries must be names of packages optionally followed by '<=' or '>=',
   white space, and a valid version number in parentheses.